### PR TITLE
Fixes to Bugs: Stacking Messages, Unintended Broadcast, Sockets Closing Properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store

--- a/p2p/p2p.py
+++ b/p2p/p2p.py
@@ -41,6 +41,9 @@ def main() -> None:
 
         quit_demo = input("Type quit to quit the demo or anything else to continue: ")
 
+    for key, user in users.items():
+        user["peer"].stop()
+        print("Stopped {key}.")
 
 if __name__ == "__main__":
     main()

--- a/p2p/p2p.py
+++ b/p2p/p2p.py
@@ -5,11 +5,11 @@ from peer import Peer
 
 def main():
     IPV4_ADDR = "0.0.0.0"
-    ports = {
-        "Anja": 8000,
-        "Makayla": 8001,
-        "Eli": 8002,
-        "Murphy": 8003,
+    users = {
+        "Anja": {"port": 8000, "peer": None},
+        "Makayla": {"port": 8001, "peer": None},
+        "Eli": {"port": 8002, "peer": None},
+        "Murphy": {"port": 8003, "peer": None},
     }
 
     Anja = Peer("0.0.0.0", 8000)

--- a/p2p/p2p.py
+++ b/p2p/p2p.py
@@ -4,10 +4,13 @@ from peer import Peer
 
 
 def main():
-    anja_port = 8000
-    makayla_port = 8001
-    eli_port = 8002
-    murphy_port = 8003
+    IPV4_ADDR = "0.0.0.0"
+    ports = {
+        "Anja": 8000,
+        "Makayla": 8001,
+        "Eli": 8002,
+        "Murphy": 8003,
+    }
 
     Anja = Peer("0.0.0.0", 8000)
     Anja.start()

--- a/p2p/p2p.py
+++ b/p2p/p2p.py
@@ -43,7 +43,7 @@ def main() -> None:
 
     for key, user in users.items():
         user["peer"].stop()
-        print("Stopped {key}.")
+        print(f"Stopping peer: {key}")
 
 if __name__ == "__main__":
     main()

--- a/p2p/p2p.py
+++ b/p2p/p2p.py
@@ -24,7 +24,7 @@ def main() -> None:
         peer.start()
         users[user]["peer"] = peer
 
-    time.sleep(1)
+    time.sleep(0.5)
 
     quit_demo = "continue"
     while quit_demo != "quit":
@@ -35,9 +35,9 @@ def main() -> None:
         if source in users and dest in users:
             source_peer: Peer = users[source]["peer"]
             connection  = source_peer.connect(CONNECTION_IPV4_ADD, users[dest]["port"])
-            time.sleep(1)
+            time.sleep(0.5)
             source_peer.send_data(message, connection)
-            time.sleep(1)
+            time.sleep(0.5)
 
         quit_demo = input("Type quit to quit the demo or anything else to continue: ")
 

--- a/p2p/p2p.py
+++ b/p2p/p2p.py
@@ -34,9 +34,9 @@ def main() -> None:
 
         if source in users and dest in users:
             source_peer: Peer = users[source]["peer"]
-            source_peer.connect(CONNECTION_IPV4_ADD, users[dest]["port"])
+            connection  = source_peer.connect(CONNECTION_IPV4_ADD, users[dest]["port"])
             time.sleep(1)
-            source_peer.send_data(message)
+            source_peer.send_data(message, connection)
             time.sleep(1)
 
         quit_demo = input("Type quit to quit the demo or anything else to continue: ")

--- a/p2p/p2p.py
+++ b/p2p/p2p.py
@@ -24,7 +24,7 @@ def main() -> None:
         peer.start()
         users[user]["peer"] = peer
 
-    time.sleep(2)
+    time.sleep(1)
 
     quit_demo = "continue"
     while quit_demo != "quit":
@@ -35,8 +35,9 @@ def main() -> None:
         if source in users and dest in users:
             source_peer: Peer = users[source]["peer"]
             source_peer.connect(CONNECTION_IPV4_ADD, users[dest]["port"])
-            time.sleep(2)
+            time.sleep(1)
             source_peer.send_data(message)
+            time.sleep(1)
 
         quit_demo = input("Type quit to quit the demo or anything else to continue: ")
 

--- a/p2p/p2p.py
+++ b/p2p/p2p.py
@@ -1,28 +1,28 @@
+from __future__ import annotations
+
 import time
 
 from peer import Peer
+from typing import TypedDict
 
+class UserEntry(TypedDict):
+    port: int
+    peer: Peer
 
-def main():
-    IPV4_ADDR = "0.0.0.0"
-    users = {
+def main() -> None:
+    ESTABLISHING_IPV4_ADDR = "0.0.0.0"
+    CONNECTION_IPV4_ADD = "127.0.0.1"
+    users: dict[str, UserEntry] = {
         "Anja": {"port": 8000, "peer": None},
         "Makayla": {"port": 8001, "peer": None},
         "Eli": {"port": 8002, "peer": None},
         "Murphy": {"port": 8003, "peer": None},
     }
 
-    Anja = Peer("0.0.0.0", 8000)
-    Anja.start()
-
-    Makayla = Peer("0.0.0.0", 8001)
-    Makayla.start()
-
-    Eli = Peer("0.0.0.0", 8002)
-    Eli.start()
-
-    Murphy = Peer("0.0.0.0", 8003)
-    Murphy.start()
+    for user in users:
+        peer = Peer(ESTABLISHING_IPV4_ADDR, users[user]["port"])
+        peer.start()
+        users[user]["peer"] = peer
 
     time.sleep(2)
 
@@ -32,45 +32,11 @@ def main():
         dest = input("Type who you want to send to: ")
         message = "https://api.thecatapi.com/v1/images/search?api_key=live_pGPtu252IVJfrslX8KvUkqhFOmid15pf8qL7r2PqXiPlnEwYzg7JWGC2MZdwTW4u"
 
-        if source == "Anja":
-            if dest == "Makayla":
-                Anja.connect("127.0.0.1", makayla_port)
-            elif dest == "Eli":
-                Anja.connect("127.0.0.1", eli_port)
-            elif dest == "Murphy":
-                Anja.connect("127.0.0.1", murphy_port)
+        if source in users and dest in users:
+            source_peer: Peer = users[source]["peer"]
+            source_peer.connect(CONNECTION_IPV4_ADD, users[dest]["port"])
             time.sleep(2)
-            Anja.send_data(message)
-
-        elif source == "Makayla":
-            if dest == "Anja":
-                Makayla.connect("127.0.0.1", anja_port)
-            elif dest == "Eli":
-                Makayla.connect("127.0.0.1", eli_port)
-            elif dest == "Murphy":
-                Makayla.connect("127.0.0.1", murphy_port)
-            time.sleep(2)
-            Makayla.send_data(message)
-
-        elif source == "Eli":
-            if dest == "Anja":
-                Eli.connect("127.0.0.1", anja_port)
-            elif dest == "Makayla":
-                Eli.connect("127.0.0.1", makayla_port)
-            elif dest == "Murphy":
-                Eli.connect("127.0.0.1", murphy_port)
-            time.sleep(2)
-            Eli.send_data(message)
-
-        elif source == "Murphy":
-            if dest == "Makayla":
-                Murphy.connect("127.0.0.1", makayla_port)
-            elif dest == "Eli":
-                Murphy.connect("127.0.0.1", eli_port)
-            elif dest == "Anja":
-                Murphy.connect("127.0.0.1", anja_port)
-            time.sleep(2)
-            Murphy.send_data(message)
+            source_peer.send_data(message)
 
         quit_demo = input("Type quit to quit the demo or anything else to continue: ")
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import socket
+from socket import socket as SocketObject
 import threading
 
 # source for demo is https://medium.com/@luishrsoares/implementing-peer-to-peer-data-exchange-in-python-8e69513489af
@@ -11,11 +12,12 @@ class Peer:
         self.host = host
         self.port = port
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.connections: set = set()
+        self.connections: set[SocketObject] = set()
 
     def connect(self, peer_host, peer_port):
-        connection = socket.create_connection((peer_host, peer_port))
-        if connection not in self.connections:
+        
+        if (peer_host, peer_port) not in [connection.getpeername() for connection in self.connections]:
+            connection = socket.create_connection((peer_host, peer_port))
             self.connections.add(connection)
             print(f"Connected to {peer_host}:{peer_port}")
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -12,7 +12,7 @@ class Peer:
         self.host = host
         self.port = port
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.socket.settimeout(2)
+        self.socket.settimeout(0.5)
         self.connections: set[SocketObject] = set()
         self.listening = threading.Event()
         self.listening.clear()

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -15,8 +15,9 @@ class Peer:
         self.connections: set[SocketObject] = set()
 
     def connect(self, peer_host, peer_port):
-        
-        if (peer_host, peer_port) not in [connection.getpeername() for connection in self.connections]:
+        if (peer_host, peer_port) not in [
+            connection.getpeername() for connection in self.connections
+        ]:
             connection = socket.create_connection((peer_host, peer_port))
             self.connections.add(connection)
             print(f"Connected to {peer_host}:{peer_port}")

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -69,3 +69,6 @@ class Peer:
     def start(self):
         listen_thread = threading.Thread(target=self.listen)
         listen_thread.start()
+
+    def stop(self):
+        pass

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -21,6 +21,7 @@ class Peer:
             connection = socket.create_connection((peer_host, peer_port))
             self.connections.add(connection)
             print(f"Connected to {peer_host}:{peer_port}")
+            return connection
 
     def listen(self):
         self.socket.bind((self.host, self.port))

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -15,9 +15,9 @@ class Peer:
 
     def connect(self, peer_host, peer_port):
         connection = socket.create_connection((peer_host, peer_port))
-
-        self.connections.append(connection)
-        print(f"Connected to {peer_host}:{peer_port}")
+        if connection not in self.connections:
+            self.connections.append(connection)
+            print(f"Connected to {peer_host}:{peer_port}")
 
     def listen(self):
         self.socket.bind((self.host, self.port))

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -7,16 +7,16 @@ import threading
 
 
 class Peer:
-    def __init__(self, host, port):
+    def __init__(self, host, port) -> None:
         self.host = host
         self.port = port
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.connections = []
+        self.connections: set = {}
 
     def connect(self, peer_host, peer_port):
         connection = socket.create_connection((peer_host, peer_port))
         if connection not in self.connections:
-            self.connections.append(connection)
+            self.connections.add(connection)
             print(f"Connected to {peer_host}:{peer_port}")
 
     def listen(self):
@@ -26,7 +26,7 @@ class Peer:
 
         while True:
             connection, address = self.socket.accept()
-            self.connections.append(connection)
+            self.connections.add(connection)
             print(f"Accepted connection from {address}")
             threading.Thread(
                 target=self.handle_client, args=(connection, address)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -18,13 +18,16 @@ class Peer:
         self.listening.clear()
     
     def connect(self, peer_host, peer_port):
-        if (peer_host, peer_port) not in [
-            connection.getpeername() for connection in self.connections
-        ]:
+        connection_names = {
+            connection.getpeername(): connection for connection in self.connections
+        }
+        if (peer_host, peer_port) not in connection_names:
             connection = socket.create_connection((peer_host, peer_port))
             self.connections.add(connection)
             print(f"Connected to {peer_host}:{peer_port}")
             return connection
+        else:
+            return connection_names[(peer_host, peer_port)]
 
     def listen(self):
         self.socket.bind((self.host, self.port))

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -11,7 +11,7 @@ class Peer:
         self.host = host
         self.port = port
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.connections: set = {}
+        self.connections: set = set()
 
     def connect(self, peer_host, peer_port):
         connection = socket.create_connection((peer_host, peer_port))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,8 @@ requires-python = ">=3.8,<=3.11"
 readme = "README.md"
 license = {text = "MIT"}
 
+[tool.pdm.scripts]
+start = "python p2p/p2p.py"
+
+[tool.setuptools]
+py-modules = ["p2p"]


### PR DESCRIPTION
# What
- `print()` messages now print in order (i.e. CatAPI message prints before prompt to quit)
- Outgoing messages are now only sent to the intended peer.
- When the user decides to quit, threads are properly closed.

# How
An extra `time.sleep()` call was added after data is sent. 

Calling `connect()` will now return the new socket object that was created OR the existing socket object for that address and port. This object can be passed to the `send_data` method as the `dest_connection`.

A `listening` flag was added to the `Peer` class that is set to false when the peer should stop listening for data. Additionally, each socket now has a timeout of 0.5 seconds, meaning that blocking calls (e.g. `recv()`) will time out and allow the while loop to check the `listening` flag more frequently. When the `listening` flag is `False`, the `while` loops will terminate, allowing the threads to die.

# Related Issues
Fixes #26 
Fixes #25 
Fixes #27 